### PR TITLE
[loadgen] support loadgen testing with backup noise

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,8 @@ tasks:
     init: |
       pip install -e .
       flask init-db
+      dd if=/dev/zero of=upload_test bs=1M count=10000
+      gp stop
     command: |
       flask run
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some workspaces that we start with `loadgen` should add backup noise. As an experiment, we do now with python flask via this branch, https://github.com/gitpod-io/template-python-flask/tree/kylos101/loadgen .

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Run loadgen with 200-300 workspaces, the python-flask ones should generate backup noise and stop themselves.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
